### PR TITLE
Add unit test for bookmark transfer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,24 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.14</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/vk-likes-transfer/src/VKNewsfeedLikesTransfer.java
+++ b/vk-likes-transfer/src/VKNewsfeedLikesTransfer.java
@@ -11,6 +11,20 @@ import com.vk.api.sdk.queries.newsfeed.NewsfeedGetQuery;
 
 public class VKNewsfeedLikesTransfer {
 
+    public static void transferLikes(VkApiClient vk, UserActor sourceActor,
+                                     UserActor targetActor, int targetOwnerId)
+            throws ApiException, ClientException {
+        NewsfeedGetQuery newsfeedGetQuery = vk.newsfeed().get(sourceActor);
+        newsfeedGetQuery.section("likes");
+        GetResponse response = newsfeedGetQuery.execute();
+        for (NewsfeedNewsfeedItemOneOf item : response.getItems()) {
+            FaveAddPostQuery addPostQuery =
+                    vk.fave().addPost(targetActor, targetOwnerId,
+                            item.getOneOf0().getPostId());
+            addPostQuery.execute();
+        }
+    }
+
         public static void main(String[] args) {
             TransportClient transportClient = new HttpTransportClient();
             VkApiClient vk = new VkApiClient(transportClient);

--- a/vk-likes-transfer/src/test/java/VKNewsfeedLikesTransferTest.java
+++ b/vk-likes-transfer/src/test/java/VKNewsfeedLikesTransferTest.java
@@ -1,0 +1,48 @@
+import com.vk.api.sdk.client.VkApiClient;
+import com.vk.api.sdk.client.actors.UserActor;
+import com.vk.api.sdk.objects.newsfeed.responses.GetResponse;
+import com.vk.api.sdk.oneofs.NewsfeedNewsfeedItemOneOf;
+import com.vk.api.sdk.queries.fave.FaveAddPostQuery;
+import com.vk.api.sdk.queries.newsfeed.NewsfeedGetQuery;
+import com.vk.api.sdk.queries.fave.Fave;
+import com.vk.api.sdk.queries.newsfeed.Newsfeed;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+public class VKNewsfeedLikesTransferTest {
+    @Test
+    void transferLikesCallsFaveAddPostWithCorrectIds() throws Exception {
+        VkApiClient vk = mock(VkApiClient.class);
+        Newsfeed newsfeed = mock(Newsfeed.class);
+        Fave fave = mock(Fave.class);
+        NewsfeedGetQuery getQuery = mock(NewsfeedGetQuery.class);
+        FaveAddPostQuery addPostQuery = mock(FaveAddPostQuery.class);
+        GetResponse response = mock(GetResponse.class);
+        NewsfeedNewsfeedItemOneOf item = mock(NewsfeedNewsfeedItemOneOf.class, RETURNS_DEEP_STUBS);
+
+        UserActor fromActor = new UserActor(1, "token1");
+        UserActor toActor = new UserActor(2, "token2");
+        int ownerId = 123;
+        int postId = 55;
+
+        when(vk.newsfeed()).thenReturn(newsfeed);
+        when(newsfeed.get(fromActor)).thenReturn(getQuery);
+        when(getQuery.section("likes")).thenReturn(getQuery);
+        when(getQuery.execute()).thenReturn(response);
+
+        when(response.getItems()).thenReturn(Collections.singletonList(item));
+        when(item.getOneOf0().getPostId()).thenReturn(postId);
+
+        when(vk.fave()).thenReturn(fave);
+        when(fave.addPost(toActor, ownerId, postId)).thenReturn(addPostQuery);
+
+        VKNewsfeedLikesTransfer.transferLikes(vk, fromActor, toActor, ownerId);
+
+        verify(fave).addPost(toActor, ownerId, postId);
+        verify(addPostQuery).execute();
+    }
+}


### PR DESCRIPTION
## Summary
- add junit and mockito dependencies
- expose `transferLikes` method for testing
- add `VKNewsfeedLikesTransferTest` verifying `FaveAddPostQuery` invocation

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476d405dc0832d8144b88e1d827328